### PR TITLE
Fix Git merge conflict annotations

### DIFF
--- a/manila/share/drivers/nexenta/ns5/nexenta_nas.py
+++ b/manila/share/drivers/nexenta/ns5/nexenta_nas.py
@@ -479,12 +479,8 @@ class NexentaNasDriver(driver.ShareDriver):
             'flags': ['file_inherit', 'dir_inherit'],
             'permissions': ['full_set'],
             'principal': 'everyone@',
-<<<<<<< HEAD
-            'type': 'allow'
-=======
             'type': 'allow',
             'index': -1
->>>>>>> 1d24c404023ad041e5da83e691c0717ec0187a83
         }
         self.nef.filesystems.acl(share_path, payload)
 


### PR DESCRIPTION
There were Git megre conflict annotations in `nexenta_nas.py` in `_update_nfs_access()`. This pull request removes them and makes the driver operational again in Ocata.