### PR TITLE
Fix deleting CIFS access rules and shares

### DIFF
--- a/manila/share/drivers/nexenta/ns5/nexenta_nas.py
+++ b/manila/share/drivers/nexenta/ns5/nexenta_nas.py
@@ -506,7 +506,7 @@ class NexentaNasDriver(driver.ShareDriver):
             if delete_rules:
                 acl_list = self.nef.get(
                     'storage/filesystems/%s/acl' % urllib.parse.quote_plus(
-                        share_path))['data']
+                        share_path))
             for rule in delete_rules:
                 for acl in acl_list:
                     principal = acl['principal']


### PR DESCRIPTION
When getting the list of existing CIFS access rules on line 507, we're trying to access the `data` key of the response. However, `jsonrpc.NefRequest.hook()` had already pulled out the contents of `data` into its equally-named attribute and returns the list directly (https://github.com/Nexenta/manila/blob/master/manila/share/drivers/nexenta/ns5/jsonrpc.py#L128).

Because of this, deleting a CIFS access rule throws an exception:
```bash
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server Traceback (most recent call last):
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 155, in _process_incoming
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 222, in dispatch
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 192, in _do_dispatch
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/manager.py", line 167, in wrapped
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     return f(self, *args, **kwargs)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/utils.py", line 519, in wrapper
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     return func(self, *args, **kwargs)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/manager.py", line 2572, in delete_share_instance
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     {'status': constants.STATUS_ERROR_DELETING})
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/oslo_utils/excutils.py", line 220, in __exit__
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     self.force_reraise()
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/oslo_utils/excutils.py", line 196, in force_reraise
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     six.reraise(self.type_, self.value, self.tb)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/manager.py", line 2555, in delete_share_instance
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     share_server=share_server
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/access.py", line 280, in update_access_rules
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     share_server=share_server)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/access.py", line 319, in _update_access_rules
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     share_server)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/access.py", line 380, in _update_rules_through_share_driver
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     share_server=share_server
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/drivers/nexenta/ns5/nexenta_nas.py", line 443, in update_access
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     self._update_cifs_access(share, add_rules, delete_rules)
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server   File "/usr/lib/python2.7/dist-packages/manila/share/drivers/nexenta/ns5/nexenta_nas.py", line 524, in _update_cifs_access
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server     share_path))['data']
2019-05-09 17:06:38.433 93886 ERROR oslo_messaging.rpc.server TypeError: list indices must be integers, not str
```

This PR removes the `['data']` getter from the API response in `_update_cifs_access()`, making it possible to delete individual CIFS access rules and CIFS-shared filesystems that have any rule.